### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ futures = "0.3"
 serde = "1.0.186"
 rand = "0.8.5"
 
+actix-web-prom = "0.6"
+
 
 
 [dependencies.mongodb]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use dotenv::dotenv;
 
 use std::sync::Arc;
 use actix_web::{web::Data, App, HttpServer, Responder, web};
+use actix_web_prom::PrometheusMetricsBuilder;
 
 use config::{Config};
 use crate::handlers::{links, rewrite};
@@ -21,10 +22,16 @@ async fn main() -> std::io::Result<()> {
 
     println!("{:?}", config);
 
+    let prometheus = PrometheusMetricsBuilder::new("api")
+        .endpoint("/metrics")
+        .build()
+        .unwrap();
+
     let mongodb = MongoRepo::new(config.clone()).await;
     let db_data = Data::new(Arc::new(mongodb));
     HttpServer::new(move ||
         App::new()
+            .wrap(prometheus.clone())
             .service(
                 web::scope("/short-links")
                     .configure(links::config))


### PR DESCRIPTION
## Summary
- expose Prometheus metrics via `/metrics`
- add `actix-web-prom` dependency

## Testing
- `cargo test` *(fails: could not download dependencies)*